### PR TITLE
AddDisplayItemsFirst

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -76,38 +76,40 @@
     %h2.title ピックアップカテゴリー
     = link_to '新規投稿商品', "#", class: "subtitle"
     %ul.item-lists
-      %li.list
-        = link_to "#" do
-          .item-img-content
-            = image_tag "item-sample.png", class: "item-img"
-            .sold-out
-              %span Sold Out!!
-          .item-info
-            %h3.item-name
-              = "商品名"
-            .item-price
-              %span
-                = "販売価格"
-                円
-                %br>/
-                (税込み)
-              .star-btn
-                = image_tag "star.png", class:"star-icon"
-                %span.star-count 0
-      %li.list
-        = link_to '#' do
-          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
-          .item-info
-            %h3.item-name
-              商品を出品してね！
-            .item-price
-              %span
-                99999999円
-                %br>/
-                (税込み)
-              .star-btn
-                = image_tag "star.png", class:"star-icon"
-                %span.star-count 0
+      - @items.each do |item|
+        %li.list
+          = link_to "#" do
+            .item-img-content
+              = image_tag item.image, class: "item-img" if item.image.present?
+              -# - if item.item_parchase_id.present?
+              -#   .sold-out
+              -#     %span Sold Out!!
+            .item-info
+              %h3.item-name
+                = item.name
+              .item-price
+                %span
+                  = item.price
+                  円
+                  %br>/
+                  (税込み)
+                .star-btn
+                  = image_tag "star.png", class:"star-icon"
+                  %span.star-count 0
+        -# %li.list
+        -#   = link_to '#' do
+        -#     = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
+        -#     .item-info
+        -#       %h3.item-name
+        -#         商品を出品してね！
+        -#       .item-price
+        -#         %span
+        -#           99999999円
+        -#           %br>/
+        -#           (税込み)
+        -#         .star-btn
+        -#           = image_tag "star.png", class:"star-icon"
+        -#           %span.star-count 0
 
 = link_to new_item_path, class: "linkto-newitems" do
   .purchase-btn

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -96,20 +96,6 @@
                 .star-btn
                   = image_tag "star.png", class:"star-icon"
                   %span.star-count 0
-        -# %li.list
-        -#   = link_to '#' do
-        -#     = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img"
-        -#     .item-info
-        -#       %h3.item-name
-        -#         商品を出品してね！
-        -#       .item-price
-        -#         %span
-        -#           99999999円
-        -#           %br>/
-        -#           (税込み)
-        -#         .star-btn
-        -#           = image_tag "star.png", class:"star-icon"
-        -#           %span.star-count 0
 
 = link_to new_item_path, class: "linkto-newitems" do
   .purchase-btn


### PR DESCRIPTION
# What
トップページに商品一覧のヴューをログイン状態に関わらずに表示。

# Add
soldoutのビューへの反映は、item_pachase_idを持っている場合に表示させるようにしているので、現段階ではitem_pachaseモデルを作っておらず、エラーになってしまうためコメントアウトにしています。

https://gyazo.com/de9592c3d19de1a2df9d0260327e153b